### PR TITLE
fix: Ensure status pages can be created if non are existing

### DIFF
--- a/src/kumaone/status_pages.py
+++ b/src/kumaone/status_pages.py
@@ -185,7 +185,7 @@ def add_status_page(
             status_page_details.pop("maintenanceList")
             return status_page_details
         with wait_for_event(ioevents.status_page_list):
-            response = _sio_call("addStatusPage", (status_page_title.title(), status_page_slug, status_page_id))
+            response = _sio_call("addStatusPage", (status_page_title.title(), status_page_slug))
             if response["ok"]:
                 console.print(
                     f":hatching_chick: Status page '{status_page_title.title()} ({status_page_slug})' has been created or updated.",


### PR DESCRIPTION
This fixes one error introduced with https://github.com/devopsforhumans/kumaone/pull/16

- fixes UnboundLocalError where status_page_id is not associated with a value
- status_page_id can not have any value when there is no status page in place

Creating and updating works now as expected

@dalwar23 PTAL! :) 